### PR TITLE
Remove proptypes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
 import { Platform } from 'react-native';
 import ActionCable from 'actioncable'
 


### PR DESCRIPTION
Although I never understood why this package is using PropTypes, I'm making this PR to remove deprecated PropTypes from React. Not sure if this makes any difference, can merge if it makes sense.

Thanks. 